### PR TITLE
[BUGFIX] Adds "null" as potential return value of method:render

### DIFF
--- a/Classes/ViewHelpers/Security/AssetAccessViewHelper.php
+++ b/Classes/ViewHelpers/Security/AssetAccessViewHelper.php
@@ -53,10 +53,10 @@ class AssetAccessViewHelper extends AbstractConditionViewHelper
      * renders <f:then> child if the current logged in FE user has access to the given asset
      * otherwise renders <f:else> child.
      *
-     * @return string
+     * @return string|null
      * @throws AspectNotFoundException
      */
-    public function render(): string
+    public function render(): ?string
     {
         return self::evaluateCondition($this->arguments) ? $this->renderThenChild() : $this->renderElseChild();
     }


### PR DESCRIPTION
Methods `renderThenChild()` and `renderElseChild()` used in `\BeechIt\FalSecuredownload\ViewHelpers\Security\AssetAccessViewHelper` can return `null`.
This is not covered by the defined return values, which leads to an exception.

This patch allows `null` as return value of method `render()`.